### PR TITLE
Fix POST error in contactAction

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -38,6 +38,11 @@ if (isset ($_GET['page'])) {
         echo $contactController->contactAction();
         }
 
+        /*if($_GET['page'] == 'success') {
+        $contactController = new ContactController();
+        echo $contactController->contactAction();
+        }*/
+
         if ($_GET['page'] == 'login') {
         $sessionController = new SessionController();
         echo $sessionController->loginAction();

--- a/src/Controllers/Website/ContactController.php
+++ b/src/Controllers/Website/ContactController.php
@@ -21,7 +21,8 @@ class ContactController extends DefaultController
             "coordonnees"=>$coordonnees
         ));
 
-        //gestion des erreurs, avec au départ $errors = 0. (header:"Location:index.php?page=success", etc)
+        //gestion des erreurs, avec au départ $errors = 0.
+
 
     }
 
@@ -29,29 +30,24 @@ class ContactController extends DefaultController
      * @return string
      */
     public function contactAction(){
-        if($_SERVER['REQUEST_METHOD'] == "POST"){
+        if ($_SERVER['REQUEST_METHOD'] == "POST") {
             $errors = [];
-            foreach ($_POST as $key => $value){
+            foreach (["firstname", "lastname", "email", "city", "message"] as $key){
                 if (empty($_POST[$key])) {
                     $errors[$key] = "Veuillez renseigner le champ " . $key;
                 }
             }
-            if (!empty($errors)){
-                return $this->twig->render('contact.html.twig', array(
+            if (!empty($errors)) {
+                return $this->twig->render('user/contact.html.twig', array(
                     'errors' => $errors
                 ));
-            }
-
-
-            else {
-
-            //On envoie les infos de contact par email
+            } else {
+                //On envoie les infos de contact par email
                 $firstname = $_POST['firstname'];
                 $lastname = $_POST['lastname'];
                 $email = $_POST['email'];
                 $city = $_POST['city'];
                 $message = $_POST['message'];
-
 
                 // Create the Transport
                 $transport = (new \Swift_SmtpTransport('smtp.mailtrap.io', 2525))
@@ -63,21 +59,18 @@ class ContactController extends DefaultController
                 // Create the Mailer using your created Transport
                 $mailer = new \Swift_Mailer($transport);
 
-
                 // Create a message
                 $message = (new \Swift_Message('Another brick in the wall'))
-                ->setFrom([$email => $firstname . $lastname])
-                ->setTo(['receiver@domain.org', 'other@domain.org' => 'Brick The Art'])
-                ->setBody($firstname. 'de'. $city. 'vous a écrit :'.$message )
+                    ->setFrom([$email => $firstname . $lastname])
+                    ->setTo(['receiver@domain.org', 'other@domain.org' => 'Brick The Art'])
+                    ->setBody($firstname. 'de'. $city. 'vous a écrit :'.$message )
                 ;
 
                 // Send the message
                 $result = $mailer->send($message);
 
-
+                return $this->twig->render('user/contact_success.html.twig');
             }
         }
-        return $this->twig->render('user/contact_success.html.twig');
     }
-
 }

--- a/src/Views/user/contact_success.html.twig
+++ b/src/Views/user/contact_success.html.twig
@@ -2,7 +2,7 @@
 
 {% block body %}
 
-    <h2 class="section_title">Votre demande a bien été envoyée ! </h2>
+    <h2 class="section_title">Votre demande a bien ete envoyee ! </h2>
     <p>Nous vous répondrons dans les meilleurs délais.</p>
     <p>En attendant vous pouvez...</p>
 


### PR DESCRIPTION
The Google reCaptcha disability prevented the contact_success.html.twig view from being rendered whereas the contact file was sent without errors.